### PR TITLE
Post requests

### DIFF
--- a/push
+++ b/push
@@ -34,8 +34,7 @@ else {
 }
 
 function go() {
-  var path = '/input/' + options.public_key + 
-    '?private_key=' + options.private_key
+  var path = '/input/' + options.public_key;
   if (params.hasOwnProperty('json')) {
     options.data = JSON.parse(options.data)
     log(options.data)
@@ -46,7 +45,16 @@ function go() {
     }
   } else path += '&' + options.field_name + '=' + options.data
   log(options.url+path)
-  http.get({ host: options.url, path: path}, function(response) {
+  var postOptions = {
+    'private_key':      options.private_key
+  }
+  postOptions[options.field_name] = options.data;
+  http.request({ 
+      host: options.url, 
+      path: path,
+      method: 'POST',
+      body: postOptions
+    }, function(response) {
     response.on('error', function() {
       console.log('error!')
       process.exit(1)


### PR DESCRIPTION
This isn't ready. 

I can't get this to work when I pipe a string "Hello world." to it, like:

```
echo "Hello world!" | ./push --url data.sparkfun.com --public_key lzELagraWDiMMRra0V6Q --private_key XXXXXXXXXX --field_name misc
```

This is an incomplete and dissatisfying adaptation for POST requests, which I hope will solve this bug. But the `http` library is poorly or not documented (or I can't find it) so I'm thinking we ought to switch to the better-supported `request` library?

https://github.com/request/request
